### PR TITLE
Multi-arch Docker build (linux/amd64 + linux/arm64) for native macOS support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -49,8 +54,9 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max 
+        cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -48,24 +48,6 @@ The extracted information is saved in an organized manner or can be [exported as
 
 ![save demo](https://image.ibb.co/dS1BqK/carbon_2.png)
 
-### Key Features
-
-#### Data Extraction
-Photon can extract the following data while crawling:
-
-- URLs (in-scope & out-of-scope)
-- URLs with parameters (`example.com/gallery.php?id=2`)
-- Intel (emails, social media accounts, amazon buckets etc.)
-- Files (pdf, png, xml etc.)
-- Secret keys (auth/API keys & hashes)
-- JavaScript files & Endpoints present in them
-- Strings matching custom regex pattern
-- Subdomains & DNS related data
-
-The extracted information is saved in an organized manner or can be [exported as json](https://github.com/s0md3v/Photon/wiki/Usage#export-formatted-result).
-
-![save demo](https://image.ibb.co/dS1BqK/carbon_2.png)
-
 #### Flexible
 Control timeout, delay, add seeds, exclude URLs matching a regex pattern and other cool stuff.
 The extensive range of [options](https://github.com/s0md3v/Photon/wiki/Usage) provided by Photon lets you crawl the web exactly the way you want.
@@ -82,18 +64,61 @@ Still, crawling can be resource intensive but Photon has some tricks up it's sle
 
 #### Docker
 
-Photon can be launched using a lightweight Docker image.
-To view results, you should open the created folder named `data`.
+Photon ships as a lightweight, multi-architecture Docker image published to the GitHub Container Registry (GHCR). The image is built for both `linux/amd64` and `linux/arm64`, so it runs natively on Linux servers, Intel Macs **and Apple Silicon (M1/M2/M3/M4)** without emulation.
 
-**Use the prebuild Docker image:**
+Crawl results are written to `/app/data` inside the container — mount a local folder there to access them on your host.
+
+**Supported platforms**
+
+| Platform | Architecture | Status |
+|----------|--------------|--------|
+| Linux    | `amd64`      | Native |
+| Linux    | `arm64`      | Native |
+| macOS (Intel)         | `amd64` | Native |
+| macOS (Apple Silicon) | `arm64` | Native |
+| Windows (WSL2)        | `amd64` | Native |
+
+**Available tags**
+
+| Tag                  | Description                                |
+|----------------------|--------------------------------------------|
+| `master` / `main`    | Latest commit on the default branch        |
+| `vX.Y.Z`             | Specific release version                   |
+| `X.Y`                | Latest patch of a minor release            |
+| `sha-<commit>`       | Build pinned to a specific commit          |
+
+**Pull & run the prebuilt image**
 ```bash
-docker run -it -v "$PWD/data:/app/data" ghcr.io/cloudmaker97/photon:master -u google.com
+docker run --rm -it \
+  -v "$PWD/data:/app/data" \
+  ghcr.io/cloudmaker97/photon:master \
+  -u google.com
 ```
 
-**Or build the docker image on your computer:**
+Docker automatically pulls the matching architecture for your machine — no `--platform` flag needed.
+
+**Build the image locally**
 ```bash
 git clone https://github.com/cloudmaker97/Photon.git
 cd Photon
 docker build -t photon .
-docker run -it -v "$PWD/data:/app/data" photon:latest -u google.com
+docker run --rm -it -v "$PWD/data:/app/data" photon:latest -u google.com
+```
+
+**Build a multi-arch image locally (optional)**
+
+If you want to reproduce the registry build (both architectures) on your own machine:
+```bash
+docker buildx create --use --name photon-builder
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t photon:multiarch \
+  --load .
+```
+
+**Tip — persisting results**
+
+The `data/` directory you mount will contain the crawl output (URLs, intel, files, JSON exports). Create it before the first run if it doesn't exist:
+```bash
+mkdir -p data
 ```


### PR DESCRIPTION
## Summary
- CI now builds the GHCR image for `linux/amd64` **and** `linux/arm64` (QEMU + buildx `platforms`), so it runs natively on Apple Silicon Macs without `--platform` workarounds.
- README Docker section rewritten: platform/tag tables, multi-arch local-build snippet, and the duplicated **Key Features** block removed.

## Test plan
- [x] CI workflow `Build and Push Docker Image` succeeds on this PR (build only, no push for PR events).
- [ ] After merge to `master`, verify the published image manifest exposes both architectures: `docker buildx imagetools inspect ghcr.io/cloudmaker97/photon:master`.
- [ ] Pull and run on an Apple Silicon Mac: `docker run --rm -it -v "$PWD/data:/app/data" ghcr.io/cloudmaker97/photon:master -u google.com` — should run without emulation warnings.
- [ ] Pull and run on an Intel/amd64 host — should still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)